### PR TITLE
Create an initial SAML Tracer privacy statement

### DIFF
--- a/support/samltracer_privacy.md
+++ b/support/samltracer_privacy.md
@@ -11,4 +11,4 @@ All processing that the SAML Tracer plugin does, happens inside the user's own b
 The extension provides an option to export the collected data into a file in JSON format. This file will contain all requests performed by the browser when the extension was running and are visible in the extension window when the export is created. The user may choose to delete sensitive form and header fields or mask them with a hash value before the export is created. This file is also stored locally and it's up to the user with whom they want to share this file and via which channel. SAML Traces provides no functionality in and of itself to share data with other parties.
 
 ## If you have questions
-If you have any questions, you can contact SimpleSAMLphp via (contact email).
+If you have any questions, you can contact SimpleSAMLphp via saml-tracer-admin@googlegroups.com.

--- a/support/samltracer_privacy.md
+++ b/support/samltracer_privacy.md
@@ -1,0 +1,14 @@
+# SAML Tracer privacy statement
+
+## About SimpleSAMLphp and SAML Tracer
+The SimpleSAMLphp project is an open source project whose legal home is Stichting The Commons Conservancy in The Netherlands.
+The SimpleSAMLphp project provides amongst others the **SAML Tracer** browser plugin, which can be downloaded in browser extension stores for installation in the user's web browser.
+
+## No personal information is collected by us
+All processing that the SAML Tracer plugin does, happens inside the user's own browser on the user's own device. _No information is shared_ with SimpleSAMLphp or any other party by installing or running the extension.
+
+## You decide what to do with exports
+The extension provides an option to export the collected data into a file in JSON format. This file will contain all requests performed by the browser when the extension was running and are visible in the extension window when the export is created. The user may choose to delete sensitive form and header fields or mask them with a hash value before the export is created. This file is also stored locally and it's up to the user with whom they want to share this file and via which channel. SAML Traces provides no functionality in and of itself to share data with other parties.
+
+## If you have questions
+If you have any questions, you can contact SimpleSAMLphp via (contact email).


### PR DESCRIPTION
The plugin runs entirely locally and the plugin creators do not get or collect any of your personal information. This is rather trivial case of privacy, so I propose to keep simple things simple and just tell it as it is.

Not add too much irrelevant boiler plate for a case where we just do not collect anything.