### PR TITLE
Proposal: recommend the cirrus identity images as the "blessed" containers for SSP

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -20,6 +20,11 @@ Here you will find the packages with the current SimpleSAMLphp versions:
 Check the [GitHub releases page](https://github.com/simplesamlphp/simplesamlphp/releases)
 in case you are looking for any other version.
 
+## Docker image
+
+If you want to use a Docker container to run SimpleSAMLphp, we recommend
+the [images created by Cirrus Identity](https://hub.docker.com/r/cirrusid/simplesamlphp/).
+
 ## Github repository
 
 The core library handling the basic SAML stuff (messages, bindings, and so on) is


### PR DESCRIPTION
These images are available and maintained, flexible so will adapt to many use cases. So it's helpful to point people to these images if they want to use SSP in Docker instead of them having to search around for solutions on their own.